### PR TITLE
i18n fixes, security fixes, removal of mandatory fadeout, don't set root pointer.

### DIFF
--- a/man/lightdm-webkit2-greeter.1
+++ b/man/lightdm-webkit2-greeter.1
@@ -258,6 +258,15 @@ config\&.get_bool(section, key)\fR
 Returns the boolean value associated with key under the "section" in the configuration file\&.
 .RE
 .PP
+The greeterutil object has some utility functions associated with it which
+are intended to make a theme author's work easier\&.
+.PP
+greeterutil\&.dirlist(path)\fR
+.RS 4
+Returns an array of strings of filenames present at "path", or Null if the
+path does not exist\&.
+.RE
+.PP
 Please see the LightDM API documentation for the complete list of calls
 available\&.  The lightdm-webkit2-greeter implements all of the LightDM API\&.
 .PP

--- a/src/lightdm-webkit2-greeter-ext.c
+++ b/src/lightdm-webkit2-greeter-ext.c
@@ -170,39 +170,24 @@ arg_to_string(JSContextRef context, JSValueRef arg, JSValueRef *exception) {
  * quote characters escaped.
  */
 static char *
-escape(const gchar *text) {
-	size_t len;
-	size_t i, j;
-	int count = 0;
+	escape(const gchar *text) {
 	gchar *escaped;
+	gchar **split;
+	gchar *result;
 
-	len = strlen(text);
+	/* Make sure all newlines, tabs, etc. are escaped. */
+	escaped = g_strescape (text, NULL);
 
-	for (i = 0; i < len; i++) {
-		if (text[i] == '\'') {
-			count++;
-		}
-	}
+	/* Split the string up on the single quote character (') */
+	split = g_strsplit (escaped, "'", -1);
 
-	if (count == 0) {
+	/* Rejoin, substituting the escaped single quote for the separator. */
+	result = g_strjoinv ("\\'", split);
 
-		return g_strdup(text);
-	}
+	g_free (escaped);
+	g_strfreev (split);
 
-	escaped = g_malloc(len + count + 1);
-
-	j = 0;
-
-	for (i = 0; i <= len; i++) {
-		if (text[i] == '\'') {
-			escaped[j] = '\\';
-			j++;
-		}
-		escaped[j] = text[i];
-		j++;
-	}
-
-	return escaped;
+	return result;
 }
 
 

--- a/src/lightdm-webkit2-greeter-ext.c
+++ b/src/lightdm-webkit2-greeter-ext.c
@@ -654,7 +654,7 @@ get_hint_cb(JSContextRef context,
 			const JSValueRef arguments[],
 			JSValueRef *exception) {
 
-	gchar *hint_name;
+	gchar *hint_name = NULL;
 	JSValueRef result;
 
 	if (argumentCount != 1) {
@@ -682,7 +682,7 @@ respond_cb(JSContextRef context,
 		   const JSValueRef arguments[],
 		   JSValueRef *exception) {
 
-	gchar *response;
+	gchar *response = NULL;
 
 	if (argumentCount != 1) {
 		return mkexception(context, exception, ARGNOTSUPPLIED);
@@ -934,7 +934,7 @@ set_language_cb(JSContextRef context,
 				const JSValueRef arguments[],
 				JSValueRef *exception) {
 
-	gchar *language;
+	gchar *language = NULL;
 
 	if (argumentCount != 1) {
 		return mkexception(context, exception, ARGNOTSUPPLIED);
@@ -962,7 +962,7 @@ gettext_cb(JSContextRef context,
 		   const JSValueRef arguments[],
 		   JSValueRef *exception) {
 
-	gchar *string;
+	gchar *string = NULL;
 	JSValueRef result;
 
 	if (argumentCount != 1) {
@@ -990,8 +990,8 @@ ngettext_cb(JSContextRef context,
 			const JSValueRef arguments[],
 			JSValueRef *exception) {
 
-	gchar *string, *plural_string;
-	unsigned int n;
+	gchar *string = NULL, *plural_string = NULL;
+	unsigned int n = 0;
 	JSValueRef result;
 
 	if (argumentCount != 3) {

--- a/src/lightdm-webkit2-greeter-ext.c
+++ b/src/lightdm-webkit2-greeter-ext.c
@@ -55,6 +55,13 @@ GKeyFile *keyfile;
 #define GREETER  ((LightDMGreeter *)  JSObjectGetPrivate (thisObject))
 #define LANGUAGE ((LightDMLanguage *) JSObjectGetPrivate (thisObject))
 
+/*
+ * Put all our translatable strings up top
+ */
+
+#define EXPECTSTRING   _("Expected a string")
+#define ARGNOTSUPPLIED _("Argument(s) not supplied")
+
 static JSClassRef
 	lightdm_greeter_class,
 	gettext_class,
@@ -129,7 +136,7 @@ arg_to_string(JSContextRef context, JSValueRef arg, JSValueRef *exception) {
 	gchar *result;
 
 	if (JSValueGetType(context, arg) != kJSTypeString) {
-		_mkexception(context, exception, _("Expected a string"));
+		_mkexception(context, exception, EXPECTSTRING);
 
 		return NULL;
 	}
@@ -651,7 +658,7 @@ get_hint_cb(JSContextRef context,
 	JSValueRef result;
 
 	if (argumentCount != 1) {
-		return mkexception(context, exception, _("Hint argument not supplied"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	hint_name = arg_to_string(context, arguments[0], exception);
@@ -678,7 +685,7 @@ respond_cb(JSContextRef context,
 	gchar *response;
 
 	if (argumentCount != 1) {
-		return mkexception(context, exception, _("Response not supplied"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	response = arg_to_string(context, arguments[0], exception);
@@ -905,11 +912,6 @@ start_session_sync_cb(JSContextRef context,
 		session = arg_to_string(context, arguments[0], exception);
 	} else if (argumentCount == 2) {
 		session = arg_to_string(context, arguments[1], exception);
-	} else if (argumentCount == 0) {
-		session = NULL;
-	} else {
-		_mkexception(context, exception, _("Incorrect parameters"));
-		return JSValueMakeBoolean(context, FALSE);
 	}
 
 	result = lightdm_greeter_start_session_sync(GREETER, session, &err);
@@ -935,7 +937,7 @@ set_language_cb(JSContextRef context,
 	gchar *language;
 
 	if (argumentCount != 1) {
-		return mkexception(context, exception, _("Language not supplied"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	language = arg_to_string(context, arguments[0], exception);
@@ -964,7 +966,7 @@ gettext_cb(JSContextRef context,
 	JSValueRef result;
 
 	if (argumentCount != 1) {
-		return mkexception(context, exception, _("Argument not supplied"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	string = arg_to_string(context, arguments[0], exception);
@@ -993,7 +995,7 @@ ngettext_cb(JSContextRef context,
 	JSValueRef result;
 
 	if (argumentCount != 3) {
-		return mkexception(context, exception, _("Needs 3 arguments"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	string = arg_to_string(context, arguments[0], exception);
@@ -1035,7 +1037,7 @@ get_conf_str_cb(JSContextRef context,
 	JSValueRef result;
 
 	if (argumentCount != 2) {
-		return mkexception(context, exception, _("Needs 2 arguments"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	section = arg_to_string(context, arguments[0], exception);
@@ -1082,7 +1084,7 @@ get_conf_num_cb(JSContextRef context,
 	GError *err = NULL;
 
 	if (argumentCount != 2) {
-		return mkexception(context, exception, _("Needs 2 arguments"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	section = arg_to_string(context, arguments[0], exception);
@@ -1125,7 +1127,7 @@ get_conf_bool_cb(JSContextRef context,
 	GError *err = NULL;
 
 	if (argumentCount != 2) {
-		return mkexception(context, exception, _("Needs 2 arguments"));
+		return mkexception(context, exception, ARGNOTSUPPLIED);
 	}
 
 	section = arg_to_string(context, arguments[0], exception);

--- a/src/lightdm-webkit2-greeter.c
+++ b/src/lightdm-webkit2-greeter.c
@@ -225,7 +225,6 @@ main(int argc, char **argv) {
 	gdk_screen_get_monitor_geometry(screen, gdk_screen_get_primary_monitor(screen), &geometry);
 	gtk_window_set_default_size(GTK_WINDOW(window), geometry.width, geometry.height);
 	gtk_window_move(GTK_WINDOW(window), geometry.x, geometry.y);
-	gdk_window_set_cursor(root_window, gdk_cursor_new_for_display(default_display, GDK_LEFT_PTR));
 
 	/* There is no window manager, so we need to implement some of its functionality */
 	gdk_window_set_events(root_window, gdk_window_get_events(root_window) | GDK_SUBSTRUCTURE_MASK);
@@ -280,6 +279,7 @@ main(int argc, char **argv) {
 							 g_strdup_printf("file://%s/%s/index.html", THEME_DIR, theme));
 
 	gtk_widget_show_all(window);
+	gdk_window_set_cursor(gtk_widget_get_window (GTK_WIDGET (window)), gdk_cursor_new_for_display(default_display, GDK_LEFT_PTR));
 
 	gtk_main();
 

--- a/src/lightdm-webkit2-greeter.c
+++ b/src/lightdm-webkit2-greeter.c
@@ -41,6 +41,7 @@
 #include <webkit2/webkit2.h>
 #include <JavaScriptCore/JavaScript.h>
 #include <glib/gi18n.h>
+#include <sys/mman.h>
 
 #include <lightdm.h>
 
@@ -176,6 +177,13 @@ main(int argc, char **argv) {
 	WebKitWebContext *context;
 	GtkCssProvider *css_provider;
 
+	/*
+	 * Prevent memory from being swapped out, since we see unencrypted
+	 * passwords.
+	 */
+	mlockall (MCL_CURRENT | MCL_FUTURE);
+
+	/* Initialize i18n */
 	setlocale (LC_ALL, "");
 	bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");

--- a/src/lightdm-webkit2-greeter.c
+++ b/src/lightdm-webkit2-greeter.c
@@ -164,31 +164,6 @@ message_received_cb(WebKitUserContentManager *manager,
 }
 
 
-static gboolean
-fade_timer_cb(gpointer data) {
-	gdouble opacity;
-	opacity = gtk_widget_get_opacity(web_view);
-	opacity -= 0.1;
-
-	if (opacity <= 0) {
-		gtk_main_quit();
-		return FALSE;
-	}
-
-	gtk_widget_set_opacity(web_view, opacity);
-
-	return TRUE;
-}
-
-
-static void
-quit_cb(void) {
-	// Fade out the greeter
-	g_timeout_add(40, (GSourceFunc) fade_timer_cb, NULL);
-
-}
-
-
 int
 main(int argc, char **argv) {
 	GdkScreen *screen;
@@ -201,9 +176,9 @@ main(int argc, char **argv) {
 	WebKitWebContext *context;
 	GtkCssProvider *css_provider;
 
-	g_unix_signal_add(SIGTERM, (GSourceFunc) quit_cb, /* is_callback */ GINT_TO_POINTER(TRUE));
-
 	gtk_init(&argc, &argv);
+
+	g_unix_signal_add(SIGTERM, (GSourceFunc) gtk_main_quit, /* is_callback */ NULL);
 
 	/* Apply greeter settings from config file */
 	keyfile = g_key_file_new();

--- a/src/lightdm-webkit2-greeter.c
+++ b/src/lightdm-webkit2-greeter.c
@@ -176,6 +176,11 @@ main(int argc, char **argv) {
 	WebKitWebContext *context;
 	GtkCssProvider *css_provider;
 
+	setlocale (LC_ALL, "");
+	bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
+	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+	textdomain (GETTEXT_PACKAGE);
+
 	gtk_init(&argc, &argv);
 
 	g_unix_signal_add(SIGTERM, (GSourceFunc) gtk_main_quit, /* is_callback */ NULL);


### PR DESCRIPTION
Here's some work I've been doing on the older lightdm-webkit-greeter, which I've ported across to the new hawtness.

1) While we had the strings translatable, we weren't setting the gettext domains at the beginning.  Also, simplified the strings down to 2, since they were mostly just variations on "arguments not supplied correctly"
2) Removed the mandatory fadeout on quite.  Here's my thinking on this: lightdm-webkit(2)-greeter isn't a greeter in and of itself; it's a shim, a toolkit to allow people to write their own greeters in html and javascript. Some people may want a fadeout on exit, others might not (me being one of them).  Since fadeout can be implemented in javascript, anyone who wants fadeout can just do it right before the start_session_sync is called.
3) Some security fixes; make sure there's no chance of null pointer use by initializing pointers, and we should set ourselves (via mlockall) to NOT be swappable, since unencrypted passwords do pass through us.
4) People who want to set the root pointer via theming were getting buggered up, and really, for a greeter, we shouldn't be messing with the root pointer anyway, since that's the pervue of a session manager.  Since we maximize our window to be the whole screen, we just set the pointer for the window, thereby leaving the root pointer alone for whatever session manager wants to set it to.

Cheers,
Scott