### PR TITLE
Set toplevel window color to the background color (black)

### DIFF
--- a/src/lightdm-webkit2-greeter.c
+++ b/src/lightdm-webkit2-greeter.c
@@ -338,6 +338,7 @@ main(int argc, char **argv) {
 	 */
 	gdk_rgba_parse(&bg_color, "#000000");
 	webkit_web_view_set_background_color(WEBKIT_WEB_VIEW(web_view), gdk_rgba_copy(&bg_color));
+	gtk_widget_override_background_color(window, GTK_STATE_NORMAL, gdk_rgba_copy(&bg_color));
 
 	/* Maybe disable the context (right-click) menu. */
 	g_signal_connect(web_view, "context-menu", G_CALLBACK(context_menu_cb), NULL);


### PR DESCRIPTION
This patch fixes #45, where the original colour of the window widget is shown before the webkit widget draws itself.

This can be applied (and was developed) over commit tag `2.1.4`.
