### PR TITLE
Combine css files in one / Removes white flash

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,7 @@
 webextension_LTLIBRARIES = liblightdm-webkit2-greeter-ext.la
 webextensiondir = $(libdir)/lightdm-webkit2-greeter
 
-if HAVE_GTK320
-ldmcssfile = lightdm-webkit2-greeter-application-3.20.css
-else
 ldmcssfile = lightdm-webkit2-greeter-application.css
-endif
 
 lightdm-webkit2-greeter-css-application.h: $(srcdir)/$(ldmcssfile) Makefile
 	$(AM_V_GEN) exo-csource --static --name=lightdm_webkit2_greeter_css_application $< >$@

--- a/src/lightdm-webkit2-greeter-application-3.20.css
+++ b/src/lightdm-webkit2-greeter-application-3.20.css
@@ -1,3 +1,0 @@
-window {
-	background: #000000;
-}

--- a/src/lightdm-webkit2-greeter-application.css
+++ b/src/lightdm-webkit2-greeter-application.css
@@ -1,3 +1,4 @@
+window,
 GtkWindow {
 	background: #000000;
 }


### PR DESCRIPTION
The nature of CSS selectors makes it possible to combine the
sheets by using multiple selectors for the ruleset.

This changeset has been tested on:

  - Ubuntu xenial, which uses GTK 3.18
  - archlinux (current), which uses GTK 3.20

* * *

As with the previous pull request, this can be applied and has been developed on revision tagged `2.1.4`.

* * *

This changeset fixes #45 properly.

* * *

Do note that I have not removed other references to `HAVE_GTK320`. I believe what's left in `configure.ac` is only the definition of the variable for the build system. If cleanup needs to be done within the file, please advise and I will amend the pull request as needed. 😄 