### PR TITLE
Workaround for CircleCI build test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
 
 dependencies:
   post:
+    - sudo apt-get update
     - >
       sudo apt-get install -y
       libgtk-3-0

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
       gnome-common
     - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe"
     - sudo apt-get update
-    - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libwebkit2gtk-4.0-dev
+    - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libwebkit2gtk-4.0-dev || true
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
       gnome-common
     - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe"
     - sudo apt-get update
-    - sudo apt-get install -y libwebkit2gtk-4.0-dev
+    - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libwebkit2gtk-4.0-dev
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -20,4 +20,6 @@ dependencies:
 
 test:
   override:
-    - cd ${CIRCLE_PROJECT_REPONAME}; ./autogen.sh && make && sudo make install
+    - ./autogen.sh
+    - make
+    - sudo make install

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 dependencies:
   post:
     - sudo apt-get update
-    - sudo apt-get upgrade -y upstart
+    - sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y upstart
     - >
       sudo apt-get install -y
       libgtk-3-0

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,9 @@ machine:
 dependencies:
   post:
     - sudo apt-get update
-    - sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y upstart
     - >
       sudo apt-get install -y
+      upstart
       libgtk-3-0
       liblightdm-gobject-1-dev
       libexo-1-dev

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ dependencies:
     - sudo apt-get update
     - >
       sudo apt-get install -y
-      upstart
       libgtk-3-0
       liblightdm-gobject-1-dev
       libexo-1-dev

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
 dependencies:
   post:
     - sudo apt-get update
+    - sudo apt-get upgrade -y upstart
     - >
       sudo apt-get install -y
       libgtk-3-0

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,10 @@ dependencies:
       exo-utils
       libdbus-glib-1-dev
       gnome-common
+    # use the repository from xenial to get libwebkit2gtk-4.0-dev
     - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe"
     - sudo apt-get update
+    # ignore the error during the installation
     - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libwebkit2gtk-4.0-dev || true
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,11 @@ dependencies:
       liblightdm-gobject-1-dev
       libexo-1-dev
       exo-utils
-      libwebkit2gtk-4.0-dev
       libdbus-glib-1-dev
       gnome-common
+    - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe"
+    - sudo apt-get update
+    - sudo apt-get install -y libwebkit2gtk-4.0-dev
 
 test:
   override:


### PR DESCRIPTION
The build test over CircleCI doesn't work at the moment because the package libwebkit2gtk-4.0-dev isn't available in Ubuntu 14.04.

Since Ubuntu 16.04 won't be available at CircleCI in the near future and the compilation of WebkitGTK+ isnt' really an option in my opinion (complex and slow), I suggest adjusting the CircleCI configuration to simply use the xenial (Ubuntu 16.04) repository to get the mentioned package (tested on a Ubuntu 14.04 machine).

Though this is an ugly solution, we would at least have a working build test for the moment.