### PR TITLE
dismiss message by keyboard only

### DIFF
--- a/themes/default/js/greeter.js
+++ b/themes/default/js/greeter.js
@@ -870,6 +870,9 @@ class Theme {
 		$msg_container.html( $msg_container.html() + text );
 		$( '#collapseTwo .user-wrap2' ).hide();
 		this.$msg_area_container.show();
+		$msg_container
+			.find('.close')
+			.focus();
 	}
 
 	dismiss_message() {


### PR DESCRIPTION
Issue #163 was annoying me to no end. Even though I don't type my password wrong all that often. This PR fixes that by automatically focusing input on the close button when a message is shown. With this PR, when a message is show you can press return (or possibly other keys) to dismiss the message.